### PR TITLE
corrected bug with converting to Number

### DIFF
--- a/query.cc
+++ b/query.cc
@@ -1229,7 +1229,7 @@ v8::Local<v8::Object> node_db::Query::row(node_db::Result* result, row_t* curren
                         value = v8::String::New(currentValue, currentLength)->ToInteger();
                         break;
                     case node_db::Result::Column::NUMBER:
-                        value = v8::Number::New(::atof(currentValue));
+                        value = v8::String::New(currentValue, currentLength)->ToNumber();
                         break;
                     case node_db::Result::Column::TIME:
                         {


### PR DESCRIPTION
corrected bug with converting to Number. If the buffer currentValue(currentRow->columns[j]) is bigger and preview value has a value bigger than current, then current value will convert wrong by adding remain digits from preview value. 

tested and work without errors.
