### PR TITLE
handle BIGINTs as strings (pre libuv)

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -14,6 +14,7 @@ void node_db::Binding::Init(v8::Handle<v8::Object> target, v8::Persistent<v8::Fu
     NODE_ADD_CONSTANT(constructorTemplate, COLUMN_TYPE_STRING, node_db::Result::Column::STRING);
     NODE_ADD_CONSTANT(constructorTemplate, COLUMN_TYPE_BOOL, node_db::Result::Column::BOOL);
     NODE_ADD_CONSTANT(constructorTemplate, COLUMN_TYPE_INT, node_db::Result::Column::INT);
+    NODE_ADD_CONSTANT(constructorTemplate, COLUMN_TYPE_BIGINT, node_db::Result::Column::BIGINT);
     NODE_ADD_CONSTANT(constructorTemplate, COLUMN_TYPE_NUMBER, node_db::Result::Column::NUMBER);
     NODE_ADD_CONSTANT(constructorTemplate, COLUMN_TYPE_DATE, node_db::Result::Column::DATE);
     NODE_ADD_CONSTANT(constructorTemplate, COLUMN_TYPE_TIME, node_db::Result::Column::TIME);

--- a/query.cc
+++ b/query.cc
@@ -5,6 +5,13 @@
 bool node_db::Query::gmtDeltaLoaded = false;
 int node_db::Query::gmtDelta;
 
+v8::Local<v8::String> v8StringFromUInt64(uint64_t num, std::ostringstream &reusableStream) {
+    reusableStream.clear();
+    reusableStream.seekp(0);
+    reusableStream << num << std::ends;
+    return v8::String::New(reusableStream.str().c_str());
+}
+
 void node_db::Query::Init(v8::Handle<v8::Object> target, v8::Persistent<v8::FunctionTemplate> constructorTemplate) {
     NODE_ADD_PROTOTYPE_METHOD(constructorTemplate, "select", Select);
     NODE_ADD_PROTOTYPE_METHOD(constructorTemplate, "from", From);
@@ -750,13 +757,14 @@ int node_db::Query::eioExecuteFinished(eio_req* eioRequest) {
             v8::Local<v8::Array> rows = v8::Array::New(totalRows);
 
             uint64_t index = 0;
+            std::ostringstream reusableStream;
             for (std::vector<row_t*>::iterator iterator = request->rows->begin(), end = request->rows->end(); iterator != end; ++iterator, index++) {
                 row_t* currentRow = *iterator;
                 v8::Local<v8::Object> row = request->query->row(request->result, currentRow);
                 v8::Local<v8::Value> eachArgv[3];
 
                 eachArgv[0] = row;
-                eachArgv[1] = v8::Number::New(index);
+                eachArgv[1] = v8StringFromUInt64(index, reusableStream);
                 eachArgv[2] = v8::Local<v8::Value>::New((index == totalRows - 1) ? v8::True() : v8::False());
 
                 request->query->Emit("each", 3, eachArgv);
@@ -779,9 +787,10 @@ int node_db::Query::eioExecuteFinished(eio_req* eioRequest) {
             argv[2] = columns;
         } else {
             v8::Local<v8::Object> result = v8::Object::New();
-            result->Set(v8::String::New("id"), v8::Number::New(request->result->insertId()));
-            result->Set(v8::String::New("affected"), v8::Number::New(request->result->affectedCount()));
-            result->Set(v8::String::New("warning"), v8::Number::New(request->result->warningCount()));
+            std::ostringstream reusableStream;
+            result->Set(v8::String::New("id"), v8StringFromUInt64(request->result->insertId(), reusableStream));
+            result->Set(v8::String::New("affected"), v8StringFromUInt64(request->result->affectedCount(), reusableStream));
+            result->Set(v8::String::New("warning"), v8StringFromUInt64(request->result->warningCount(), reusableStream));
             argv[1] = result;
         }
 
@@ -860,6 +869,7 @@ void node_db::Query::executeAsync(execute_request_t* request) {
 
                 row_t row;
                 uint64_t index = 0;
+                std::ostringstream reusableStream;
 
                 while (request->result->hasNext()) {
                     row.columnLengths = (unsigned long*) request->result->columnLengths();
@@ -869,7 +879,7 @@ void node_db::Query::executeAsync(execute_request_t* request) {
                     v8::Local<v8::Value> eachArgv[3];
 
                     eachArgv[0] = jsRow;
-                    eachArgv[1] = v8::Number::New(index);
+                    eachArgv[1] = v8StringFromUInt64(index, reusableStream);
                     eachArgv[2] = v8::Local<v8::Value>::New(request->result->hasNext() ? v8::True() : v8::False());
 
                     this->Emit("each", 3, eachArgv);
@@ -885,9 +895,10 @@ void node_db::Query::executeAsync(execute_request_t* request) {
                 argv[2] = columns;
             } else {
                 v8::Local<v8::Object> result = v8::Object::New();
-                result->Set(v8::String::New("id"), v8::Number::New(request->result->insertId()));
-                result->Set(v8::String::New("affected"), v8::Number::New(request->result->affectedCount()));
-                result->Set(v8::String::New("warning"), v8::Number::New(request->result->warningCount()));
+                std::ostringstream reusableStream;
+                result->Set(v8::String::New("id"), v8StringFromUInt64(request->result->insertId(), reusableStream));
+                result->Set(v8::String::New("affected"), v8StringFromUInt64(request->result->affectedCount(), reusableStream));
+                result->Set(v8::String::New("warning"), v8StringFromUInt64(request->result->warningCount(), reusableStream));
                 argv[1] = result;
             }
 
@@ -1310,9 +1321,10 @@ v8::Local<v8::Object> node_db::Query::row(node_db::Result* result, row_t* curren
                             std::istringstream stream(currentValue);
                             std::string item;
                             uint64_t index = 0;
+                            std::ostringstream reusableStream;
                             while (std::getline(stream, item, ',')) {
                                 if (!item.empty()) {
-                                    values->Set(v8::Integer::New(index++), v8::String::New(item.c_str()));
+                                    values->Set(v8StringFromUInt64(index++, reusableStream), v8::String::New(item.c_str()));
                                 }
                             }
                             value = values;

--- a/result.h
+++ b/result.h
@@ -16,6 +16,7 @@ class Result {
                     STRING,
                     TEXT,
                     INT,
+                    BIGINT,
                     NUMBER,
                     DATE,
                     TIME,


### PR DESCRIPTION
First of all, I apologize for submitting a commit that is based the commit before the support for libuv (806d7b47fe036bdafb4eb3770ed3aea9abaa972b). I did this because it does not build for node < 0.7.9.
Nevertheless, the changes in this pull request should be easily merged in your repo as it is now.

Now into the problem. 
I have been struggling with the need of BIGINTs. However, the current version of node-db/node-db-mysql handle them as INTs and cast them to Javascript numbers which, like all we know, are prone to precision inaccuracies for after the 53th bit.

I have been working around by using CAST(xx AS CHAR) in SELECT commands but, not only it is cumbersome, it is not possible to do the same thing for getting the insertIds for INSERT commands (which get internally converted from uint64_t to v8::Number).

What I propose with this commit is to treat insertId, affectedRows, warning, indexes (emit.each) and data from BIGINT columns as v8::String. I am doing this in a forceful manner, and that is where my doubt lies. 
1. Should we allow the "cast" argument to be applied to a specified list of columns? : As of the current version of node-db, since there is no way to disable casting by column name (only globally by setting the cast parameter to false in the call to select/insert/etc.), I thought it would be easier to treat all BIGINTs as strings.
2. The other approach would be to look at the number and check whether it is safely representable in v8::Number and convert it to v8::String only if it is not. However, I think it would be kind of "weird" to get columns having a mix Number and String, so I vote that option down.
3. The other approach, which is like I followed (also for being the easiest) is to treat BIGINT as string. If the return is fixed type, it is easier to handle because the user must be aware of precision issues. Javascript non-strict comparisons against numbers also apply correctly (eg. "33" < 4) and parseInt also works (of course with precision limitations).

Personally I believe 3 is the best solution, as there are not that many projects using BIGINT and even if they are I believe developers must be aware of the limitations of javascript numbers. 

What is your opinion?

By the way, there is a similar conversation going on at https://github.com/felixge/node-mysql/issues/207
