### PR TITLE
Update node.js bindings to support all node.js versions

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -88,7 +88,7 @@ v8::Handle<v8::Value> node_db::Binding::Connect(const v8::Arguments& args) {
 
         uv_work_t* req = new uv_work_t();
         req->data = request;
-        uv_queue_work(uv_default_loop(), req, uvConnect, uvConnectFinished);
+        uv_queue_work(uv_default_loop(), req, uvConnect, (uv_after_work_cb)uvConnectFinished);
 
 #if NODE_VERSION_AT_LEAST(0, 7, 9)
 	uv_ref((uv_handle_t *)&g_async);

--- a/binding.h
+++ b/binding.h
@@ -2,7 +2,9 @@
 #ifndef BINDING_H_
 #define BINDING_H_
 
+#include <v8.h>
 #include <node.h>
+#include <node_buffer.h>
 #include <node_version.h>
 #include <string>
 #include "./node_defs.h"
@@ -33,6 +35,7 @@ class Binding : public EventEmitter {
         static v8::Handle<v8::Value> Escape(const v8::Arguments& args);
         static v8::Handle<v8::Value> Name(const v8::Arguments& args);
         static v8::Handle<v8::Value> Query(const v8::Arguments& args);
+	static uv_async_t g_async;
         static void uvConnect(uv_work_t* uvRequest);
         static void uvConnectFinished(uv_work_t* uvRequest);
         static void connect(connect_request_t* request);

--- a/query.cc
+++ b/query.cc
@@ -398,7 +398,7 @@ v8::Handle<v8::Value> node_db::Query::Insert(const v8::Arguments& args) {
     uint32_t argsLength = args.Length();
 
     int fieldsIndex = -1, valuesIndex = -1;
-
+  
     if (argsLength > 0) {
         ARG_CHECK_STRING(0, table);
 
@@ -455,7 +455,9 @@ v8::Handle<v8::Value> node_db::Query::Insert(const v8::Arguments& args) {
                     }
 
                     try {
-                        query->sql << query->fieldName(fields->Get(i));
+		      //query->sql << query->fieldName(fields->Get(i));
+		      v8::String::Utf8Value fieldName(fields->Get(i));
+		      query->sql << *fieldName;
                     } catch(const node_db::Exception& exception) {
                         THROW_EXCEPTION(exception.what())
                     }

--- a/query.cc
+++ b/query.cc
@@ -398,7 +398,7 @@ v8::Handle<v8::Value> node_db::Query::Insert(const v8::Arguments& args) {
     uint32_t argsLength = args.Length();
 
     int fieldsIndex = -1, valuesIndex = -1;
-  
+
     if (argsLength > 0) {
         ARG_CHECK_STRING(0, table);
 
@@ -455,9 +455,9 @@ v8::Handle<v8::Value> node_db::Query::Insert(const v8::Arguments& args) {
                     }
 
                     try {
-		      //query->sql << query->fieldName(fields->Get(i));
-		      v8::String::Utf8Value fieldName(fields->Get(i));
-		      query->sql << *fieldName;
+		        v8::String::Utf8Value fieldName(fields->Get(i));
+                        //query->fieldName(fields->Get(i));
+		        query->sql << *fieldName;
                     } catch(const node_db::Exception& exception) {
                         THROW_EXCEPTION(exception.what())
                     }

--- a/query.cc
+++ b/query.cc
@@ -5,6 +5,8 @@
 bool node_db::Query::gmtDeltaLoaded = false;
 int node_db::Query::gmtDelta;
 
+uv_async_t node_db::Query::g_async;
+
 void node_db::Query::Init(v8::Handle<v8::Object> target, v8::Persistent<v8::FunctionTemplate> constructorTemplate) {
     NODE_ADD_PROTOTYPE_METHOD(constructorTemplate, "select", Select);
     NODE_ADD_PROTOTYPE_METHOD(constructorTemplate, "from", From);
@@ -649,7 +651,12 @@ v8::Handle<v8::Value> node_db::Query::Execute(const v8::Arguments& args) {
         req->data = request;
         uv_queue_work(uv_default_loop(), req, uvExecute, uvExecuteFinished);
 
+#if NODE_VERSION_AT_LEAST(0, 7, 9)
+        uv_ref((uv_handle_t *)&g_async);
+#else
         uv_ref(uv_default_loop());
+#endif
+
     } else {
         request->query->executeAsync(request);
     }
@@ -813,7 +820,12 @@ void node_db::Query::uvExecuteFinished(uv_work_t* uvRequest) {
         }
     }
 
+#if NODE_VERSION_AT_LEAST(0, 7, 9)
+    uv_unref((uv_handle_t *)&g_async);
+#else
     uv_unref(uv_default_loop());
+#endif
+
     request->query->Unref();
 
     Query::freeRequest(request);

--- a/query.cc
+++ b/query.cc
@@ -651,7 +651,7 @@ v8::Handle<v8::Value> node_db::Query::Execute(const v8::Arguments& args) {
 
         uv_work_t* req = new uv_work_t();
         req->data = request;
-        uv_queue_work(uv_default_loop(), req, uvExecute, uvExecuteFinished);
+        uv_queue_work(uv_default_loop(), req, uvExecute, (uv_after_work_cb)uvExecuteFinished);
 
 #if NODE_VERSION_AT_LEAST(0, 7, 9)
         uv_ref((uv_handle_t *)&g_async);

--- a/query.h
+++ b/query.h
@@ -2,6 +2,7 @@
 #ifndef QUERY_H_
 #define QUERY_H_
 
+#include <v8.h>
 #include <stdlib.h>
 #include <node.h>
 #include <node_buffer.h>
@@ -66,6 +67,7 @@ class Query : public EventEmitter {
         static v8::Handle<v8::Value> Delete(const v8::Arguments& args);
         static v8::Handle<v8::Value> Sql(const v8::Arguments& args);
         static v8::Handle<v8::Value> Execute(const v8::Arguments& args);
+        static uv_async_t g_async;
         static void uvExecute(uv_work_t* uvRequest);
         static void uvExecuteFinished(uv_work_t* uvRequest);
         void executeAsync(execute_request_t* request);


### PR DESCRIPTION
this fix is backwards compatible and enables users to use node-db with the latest versions of node
