### PR TITLE
uv_after_work_cb backward compatibility / test case for multiple query results

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -88,7 +88,7 @@ v8::Handle<v8::Value> node_db::Binding::Connect(const v8::Arguments& args) {
 
         uv_work_t* req = new uv_work_t();
         req->data = request;
-        uv_queue_work(uv_default_loop(), req, uvConnect, uvConnectFinished);
+        uv_queue_work(uv_default_loop(), req, uvConnect, (uv_after_work_cb)uvConnectFinished);
 
 #if NODE_VERSION_AT_LEAST(0, 7, 9)
 	uv_ref((uv_handle_t *)&g_async);

--- a/query.cc
+++ b/query.cc
@@ -649,7 +649,7 @@ v8::Handle<v8::Value> node_db::Query::Execute(const v8::Arguments& args) {
 
         uv_work_t* req = new uv_work_t();
         req->data = request;
-        uv_queue_work(uv_default_loop(), req, uvExecute, uvExecuteFinished);
+        uv_queue_work(uv_default_loop(), req, uvExecute, (uv_after_work_cb)uvExecuteFinished);
 
 #if NODE_VERSION_AT_LEAST(0, 7, 9)
         uv_ref((uv_handle_t *)&g_async);

--- a/tests.js
+++ b/tests.js
@@ -47,6 +47,26 @@ exports.get = function(createDbClient, quoteName) {
             test.equal(quoteName + "table" + quoteName + ".*", client.name("table.*"));
             
             test.done();
+        },
+        "multiple results": function(test) {
+            var client = this.client;
+            test.expect(1);
+
+            client.query(
+                'CREATE PROCEDURE multiple_result () ' +
+                'BEGIN ' +
+                '    SELECT 0; ' +
+                '    SELECT 1; ' +
+                'END'
+            ).execute(function () {
+                client.query('call multiple_result()').execute(function (error1, rows, cols) {
+                    client.query('call multiple_result()').execute(function (error2, rows, cols) {
+                        test.equal(null, error2);
+                        client.query('DROP PROCEDURE IF EXISTS multiple_result').execute();
+                        test.done();
+                    });
+                });
+            });
         }
     });
 


### PR DESCRIPTION
This patch adds an explicit cast to the 4th argument of 'uv_queue_work' calls for backward compatibility (see https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10 and https://github.com/rbranson/node-ffi/commit/fdeff41ae8b1cca31d4707d7b61253c45181b8fa). Without this patch I was unable to compile the latest code from master on node 0.8.18.

I've also added a test case for multiple results returned by a single query (coverage for the patch I submitted to node-db-mysql - https://github.com/mariano/node-db-mysql/pull/101)
